### PR TITLE
24/25: Change timer counter type to uint32_t and reset value to avoid overflow

### DIFF
--- a/Labs/lab2/lab2.c
+++ b/Labs/lab2/lab2.c
@@ -4,7 +4,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-extern int counter;
+extern uint32_t counter;
 
 int main(int argc, char *argv[]) {
 

--- a/Labs/lab2/lab2.c
+++ b/Labs/lab2/lab2.c
@@ -63,6 +63,7 @@ int(timer_test_int)(uint8_t time) {
             case HARDWARE: /* hardware interrupt notification */                
                 if (msg.m_notify.interrupts & irq_set) { /* subscribed interrupt */
                    timer_int_handler(); 
+                   //if (counter == (UINT32_MAX - (UINT32_MAX % 60)) ) { counter = 0; }  // "esvazia" o counter para evitar overflow e preserva a lógica do módulo para o lab
                    if(counter%60==0){
                       timer_print_elapsed_time();
                       time--;

--- a/Labs/lab2/timer.c
+++ b/Labs/lab2/timer.c
@@ -66,7 +66,6 @@ int (timer_unsubscribe_int)() {
 }
 
 void (timer_int_handler)() {
-  if (counter == UINT32_MAX){counter = UINT32_MAX % 60;} // "esvazia" o counter para evitar overflow e preserva a lógica do módulo para o lab
   counter++;
 }
 

--- a/Labs/lab2/timer.c
+++ b/Labs/lab2/timer.c
@@ -4,7 +4,7 @@
 #include "i8254.h"
 
 int hook_id = 0;
-int counter = 0;
+uint32_t counter = 0;
 
 int (timer_set_frequency)(uint8_t timer, uint32_t freq) {
 
@@ -66,6 +66,7 @@ int (timer_unsubscribe_int)() {
 }
 
 void (timer_int_handler)() {
+  if (counter == UINT32_MAX){counter = UINT32_MAX % 60;} // "esvazia" o counter para evitar overflow e preserva a lógica do módulo para o lab
   counter++;
 }
 

--- a/Labs/lab3/lab3.c
+++ b/Labs/lab3/lab3.c
@@ -113,6 +113,7 @@ int(kbd_test_timed_scan)(uint8_t n) {
                     }
                     if (msg.m_notify.interrupts & irq_set_TIMER) {
                         timer_int_handler();
+                        //if (counter_TIMER == (UINT32_MAX - (UINT32_MAX % 60)) ) { counter_TIMER = 0; }  // "esvazia" o counter para evitar overflow e preserva a lógica do módulo para o lab
                         if (counter_TIMER % 60 == 0) seconds++;
                     }
             }

--- a/Labs/lab3/lab3.c
+++ b/Labs/lab3/lab3.c
@@ -11,7 +11,7 @@
 #include "timer.c"
 
 extern uint32_t counter_KBC;
-extern int counter_TIMER;
+extern uint32_t counter_TIMER;
 extern uint8_t scancode;
 
 int main(int argc, char *argv[]) {

--- a/Labs/lab3/timer.c
+++ b/Labs/lab3/timer.c
@@ -6,7 +6,7 @@
 #include "i8254.h"
 
 int hook_id_TIMER = 0;
-int counter_TIMER = 0;
+uint32_t counter_TIMER = 0;
 
 int (timer_set_frequency)(uint8_t timer, uint32_t freq) {
 
@@ -59,6 +59,7 @@ int (timer_unsubscribe_int)() {
 }
 
 void (timer_int_handler)() {
+  if (counter_TIMER == UINT32_MAX){counter_TIMER = UINT32_MAX % 60;} // "esvazia" o counter para evitar overflow e preserva a lógica do módulo para o lab
   counter_TIMER++;
 }
 

--- a/Labs/lab3/timer.c
+++ b/Labs/lab3/timer.c
@@ -59,7 +59,6 @@ int (timer_unsubscribe_int)() {
 }
 
 void (timer_int_handler)() {
-  if (counter_TIMER == UINT32_MAX){counter_TIMER = UINT32_MAX % 60;} // "esvazia" o counter para evitar overflow e preserva a lógica do módulo para o lab
   counter_TIMER++;
 }
 


### PR DESCRIPTION
From issues detected in class (counter overflow resulting in incorrect counting of seconds)

In labs 2 and 3:
- Changes the timer counter type to uint32_t (as negative counters are not necessary + holds higher number :) )
- Implements a safety measure in `timer_int_handler` to reset the counter to avoid overflows while preserving the necessary logic

also that magic `60` frequency could be changed to `sys_hz()` but not critical
maybe the same problem exists in further labs but I assume students will figure it out by then so I ignored it  :boom: 